### PR TITLE
Add dedicated logo asset and favicon updates

### DIFF
--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,22 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="brandGradient" x1="12" y1="8" x2="52" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#6EE7FF" />
+      <stop offset="1" stop-color="#A855F7" />
+    </linearGradient>
+    <linearGradient id="accentGradient" x1="20" y1="14" x2="44" y2="50" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F8FAFC" />
+      <stop offset="1" stop-color="#E2E8F0" stop-opacity="0.8" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="56" height="56" rx="16" fill="#020617" />
+  <rect x="6" y="6" width="52" height="52" rx="14" stroke="url(#brandGradient)" stroke-width="2" />
+  <path
+    d="M25.5 18H33c5.4 0 9.5 3.4 9.5 8.7 0 4.5-3.2 7.7-8 8.4l7.8 10.9h-6.9l-7.1-10.1H29v10.1h-3.5V18Zm7.2 12.7c3.7 0 6-1.9 6-4.9 0-3.1-2.3-4.9-6.1-4.9H29v9.8h3.7Z"
+    fill="url(#accentGradient)"
+  />
+  <path
+    d="M20 46.5c1.8 1.7 4.7 2.6 8.6 2.6 5.6 0 9.4-2 11.7-4.4l-2.4-2.5c-1.9 2-5.1 3.6-9.3 3.6-2.6 0-4.4-.5-5.7-1.5-1.2-.9-1.8-2-1.8-3.3 0-1.3.5-2.4 1.7-3.2 1.4-1 3.4-1.4 5.7-1.4 1.4 0 2.9.1 4.3.4 1.4.2 2.6.6 3.8 1.1l2.5-2.3c-1.4-.8-3-1.4-4.7-1.8-1.7-.4-3.4-.5-5.2-.5-3.2 0-5.8.6-7.8 2-2.2 1.5-3.3 3.5-3.3 6 0 2.4.9 4.5 2.7 6Z"
+    fill="url(#brandGradient)"
+  />
+</svg>

--- a/index.html
+++ b/index.html
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
 import { Sparkle, ArrowRight } from 'lucide-react';
 
+const LOGO_SRC = 'assets/logo.svg';
+
 // =============== Utilities ===============
 function easeOutCubic(x) {
   return 1 - Math.pow(1 - x, 3);
@@ -40,6 +42,23 @@ function Reveal({ children, delay = 0 }) {
 
 // =============== App ===============
 export default function BlackScholesLanding() {
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const existing = document.querySelector("link[rel='icon']");
+    const link = existing ?? document.createElement('link');
+    link.rel = 'icon';
+    link.href = LOGO_SRC;
+    link.type = 'image/svg+xml';
+    if (!existing) {
+      document.head.appendChild(link);
+    }
+    return () => {
+      if (!existing && link.parentNode) {
+        link.parentNode.removeChild(link);
+      }
+    };
+  }, []);
+
   return (
     <>
       {/* Global smooth scroll */}
@@ -340,7 +359,10 @@ function NavBar() {
     <header className="fixed top-0 left-0 right-0 z-50">
       <div className="mx-auto max-w-7xl px-4">
         <div className="mt-4 flex items-center justify-between rounded-full border border-neutral-800/60 bg-neutral-900/40 backdrop-blur supports-[backdrop-filter]:bg-neutral-900/40 px-4 py-2">
-          <a href="#" className="font-medium tracking-tight">Black Scholes</a>
+          <a href="#" className="flex items-center gap-3 font-medium tracking-tight text-white">
+            <img src={LOGO_SRC} alt="Black Scholes logo" className="h-8 w-8" />
+            <span>Black Scholes</span>
+          </a>
           <nav className="hidden md:flex items-center gap-6 text-sm text-neutral-300">
             <a className="hover:text-white" href="#tailored">Systems</a>
             <a className="hover:text-white" href="#process">Process</a>


### PR DESCRIPTION
## Summary
- add a gradient SVG logo asset for the Black Scholes brand
- show the logo once beside the firm name in the navigation bar
- configure the application favicon to reuse the new logo asset

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68e0662bc4508320915adf4dc894155e